### PR TITLE
Fix noisy null-safety warning

### DIFF
--- a/lib/src/build_tracker/build_tracker.dart
+++ b/lib/src/build_tracker/build_tracker.dart
@@ -120,7 +120,7 @@ class BuildTracker {
 
     if (value && !_frameCallbackScheduled) {
       _frameCallbackScheduled = true;
-      WidgetsBinding.instance!.addPostFrameCallback(_frameCallback);
+      WidgetsBinding.instance.addPostFrameCallback(_frameCallback);
     }
   }
 
@@ -194,7 +194,7 @@ class BuildTracker {
 
     if (_enabled && !_frameCallbackScheduled) {
       _frameCallbackScheduled = true;
-      WidgetsBinding.instance!.addPostFrameCallback(_frameCallback);
+      WidgetsBinding.instance.addPostFrameCallback(_frameCallback);
     }
   }
 

--- a/lib/src/build_tracker/test_tracking_build_owner.dart
+++ b/lib/src/build_tracker/test_tracking_build_owner.dart
@@ -13,6 +13,6 @@ class TrackingBuildOwnerAutomatedTestWidgetsFlutterBinding
     if (WidgetsBinding.instance == null) {
       TrackingBuildOwnerAutomatedTestWidgetsFlutterBinding();
     }
-    return WidgetsBinding.instance!;
+    return WidgetsBinding.instance;
   }
 }

--- a/lib/src/build_tracker/tracking_build_owner.dart
+++ b/lib/src/build_tracker/tracking_build_owner.dart
@@ -38,7 +38,7 @@ class TrackingBuildOwnerWidgetsFlutterBinding extends WidgetsFlutterBinding
     if (WidgetsBinding.instance == null) {
       TrackingBuildOwnerWidgetsFlutterBinding();
     }
-    return WidgetsBinding.instance!;
+    return WidgetsBinding.instance;
   }
 }
 

--- a/lib/src/tools/providers.dart
+++ b/lib/src/tools/providers.dart
@@ -9,12 +9,12 @@ import 'package:noob/noob.dart';
 class LastPointerEventProviderStateNotifier
     extends StateNotifier<BuiltMap<int, PointerEvent>> {
   LastPointerEventProviderStateNotifier() : super(BuiltMap()) {
-    WidgetsBinding.instance!.pointerRouter.addGlobalRoute(_handler);
+    WidgetsBinding.instance.pointerRouter.addGlobalRoute(_handler);
   }
 
   @override
   void dispose() {
-    WidgetsBinding.instance!.pointerRouter.removeGlobalRoute(_handler);
+    WidgetsBinding.instance.pointerRouter.removeGlobalRoute(_handler);
     super.dispose();
   }
 
@@ -47,7 +47,7 @@ final lastPointerEventProvider = StateNotifierProvider.autoDispose<
 ///
 class GlobalPositionStateNotifier extends StateNotifier<Rect?> {
   GlobalPositionStateNotifier(this.context) : super(null) {
-    WidgetsBinding.instance!.addPostFrameCallback(_callback);
+    WidgetsBinding.instance.addPostFrameCallback(_callback);
   }
 
   final BuildContext context;
@@ -61,7 +61,7 @@ class GlobalPositionStateNotifier extends StateNotifier<Rect?> {
       if (state != rect) {
         state = rect;
       }
-      WidgetsBinding.instance!.addPostFrameCallback(_callback);
+      WidgetsBinding.instance.addPostFrameCallback(_callback);
     }
   }
 }


### PR DESCRIPTION
# Problem

When importing 'package:noob/noob.dart', with flutter stable v3.0.5, we see a bunch of red warnings in the console about using the null-check operator `!` over `WidgetsBinding.instance`, that is not nullable.

<details>
  <summary>Warnings as seen in console</summary>

```
/C:/src/flutter/.pub-cache/hosted/pub.dartlang.org/noob-0.0.7/lib/src/tools/providers.dart:12:20: Warning: Operand of null-aware operation '!' has type 'WidgetsBinding' which excludes null.
 - 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('/C:/src/flutter/packages/flutter/lib/src/widgets/binding.dart').
    WidgetsBinding.instance!.pointerRouter.addGlobalRoute(_handler);
                   ^
/C:/src/flutter/.pub-cache/hosted/pub.dartlang.org/noob-0.0.7/lib/src/tools/providers.dart:17:20: Warning: Operand of null-aware operation '!' has type 'WidgetsBinding' which excludes null.
 - 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('/C:/src/flutter/packages/flutter/lib/src/widgets/binding.dart').
    WidgetsBinding.instance!.pointerRouter.removeGlobalRoute(_handler);
                   ^
/C:/src/flutter/.pub-cache/hosted/pub.dartlang.org/noob-0.0.7/lib/src/tools/providers.dart:50:20: Warning: Operand of null-aware operation '!' has type 'WidgetsBinding' which excludes null.
 - 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('/C:/src/flutter/packages/flutter/lib/src/widgets/binding.dart').
    WidgetsBinding.instance!.addPostFrameCallback(_callback);
                   ^
/C:/src/flutter/.pub-cache/hosted/pub.dartlang.org/noob-0.0.7/lib/src/tools/providers.dart:64:22: Warning: Operand of null-aware operation '!' has type 'WidgetsBinding' which excludes null.
 - 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('/C:/src/flutter/packages/flutter/lib/src/widgets/binding.dart').
      WidgetsBinding.instance!.addPostFrameCallback(_callback);
                     ^
/C:/src/flutter/.pub-cache/hosted/pub.dartlang.org/noob-0.0.7/lib/src/build_tracker/build_tracker.dart:123:22: Warning: Operand of null-aware operation '!' has type 'WidgetsBinding' which excludes null.
 - 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('/C:/src/flutter/packages/flutter/lib/src/widgets/binding.dart').
      WidgetsBinding.instance!.addPostFrameCallback(_frameCallback);
                     ^
/C:/src/flutter/.pub-cache/hosted/pub.dartlang.org/noob-0.0.7/lib/src/build_tracker/build_tracker.dart:197:22: Warning: Operand of null-aware operation '!' has type 'WidgetsBinding' which excludes null.
 - 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('/C:/src/flutter/packages/flutter/lib/src/widgets/binding.dart').
      WidgetsBinding.instance!.addPostFrameCallback(_frameCallback);
                     ^
/C:/src/flutter/.pub-cache/hosted/pub.dartlang.org/noob-0.0.7/lib/src/build_tracker/tracking_build_owner.dart:41:27: Warning: Operand of null-aware operation '!' has type 'WidgetsBinding' which excludes null.
 - 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('/C:/src/flutter/packages/flutter/lib/src/widgets/binding.dart').
    return WidgetsBinding.instance!;
                          ^
```
</details>
<details>
<summary>flutter doctor</summary>

```
Doctor summary (to see all details, run flutter doctor -v):
[√] Flutter (Channel stable, 3.0.5, on Microsoft Windows [Versi¢n 10.0.22000.856], locale es-ES)
[√] Android toolchain - develop for Android devices (Android SDK version 33.0.0)
[√] Chrome - develop for the web
[X] Visual Studio - develop for Windows
    X Visual Studio not installed; this is necessary for Windows development.
      Download at https://visualstudio.microsoft.com/downloads/.
      Please install the "Desktop development with C++" workload, including all of its default components
[√] Android Studio (version 2021.2)
[√] Connected device (3 available)
[√] HTTP Host Availability

! Doctor found issues in 1 category.
```

</details>

# Solution

Remove redundant null-check operator `!` over `WidgetsBinding.instance`

# Unresolved topics

## Compatibility with previous versions
I'm assuming this was working without warnings in previous versions of flutter, where WidgetsBinding was nullable, likely to not supporting null-safety at that time.

We may need to ensure that compatibility between different flutter versions and this package, but since I don't know much about this right now, I didn't resolve this aspect.

## TrackingBuildOwnerWidgetsFlutterBinding.ensureInitialized is not working

`TrackingBuildOwnerWidgetsFlutterBinding.ensureInitialized` is not working, as it's checking if `WidgetsBinding.instance` is null, which won't happen:

```
static WidgetsBinding ensureInitialized() {
  if (WidgetsBinding.instance == null) {
    TrackingBuildOwnerWidgetsFlutterBinding();
  }
  return WidgetsBinding.instance;
}
```

But calling `TrackingBuildOwnerWidgetsFlutterBinding();` instead before creating a BuildTracker works fine:

```
void main() {
  TrackingBuildOwnerWidgetsFlutterBinding();
  BuildTracker();
  runApp(...);
}
```

There seems to be some changes in recent versions of flutter about how this is handled; and calling `TrackingBuildOwnerWidgetsFlutterBinding();` directly sounds like a small hack, but it works for me.

## Increase version number and add entry in the changelog

As I don't know if this must be a 0.0.8 or a 1.0.0 (if fixing ensureInitialized ends up in a breaking change), I still haven't added an entry on the changelog.